### PR TITLE
fix inconsistent directory naming

### DIFF
--- a/workshop/content/StaticWebHosting/Repository.en.md
+++ b/workshop/content/StaticWebHosting/Repository.en.md
@@ -34,7 +34,7 @@ The AWS Cloud9 development environment comes with AWS managed temporary credenti
     ```
 1.  Create a new directory for your CodeCommit repo:
     ```
-    mkdir ../WildRydesVue && cd ../WildRydesVue
+    mkdir ../wild-rydes && cd ../wild-rydes
     ```
 1.  Initialize a new git repository:
     ```

--- a/workshop/content/UserManagement/AppClient.en.md
+++ b/workshop/content/UserManagement/AppClient.en.md
@@ -21,7 +21,7 @@ A new App client has been created by the AWS Amplify build. Let's take a look at
 1. **Click** the new user pool to open the Pool Details page
 1. From the Pool Details page, select **App clients** from the **General settings** section in the left navigation bar.
 
-1. You will see that a new App client has been generated.  Your web application is configured to use this App client via a config file located in `wildrydes/src/aws-exports.js`.
+1. You will see that a new App client has been generated.  Your web application is configured to use this App client via a config file located in `wild-rydes/src/aws-exports.js`.
 
 
 #### How it Works: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The folder name wild-rydes should be consistently used across all parts of the labs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
