### PR TITLE
Cleanup IAM service role used by Amplify backend

### DIFF
--- a/workshop/content/Cleanup/Module1.en.md
+++ b/workshop/content/Cleanup/Module1.en.md
@@ -11,12 +11,21 @@ Delete the AWS Amplify Console application and optionally the AWS CodeCommit or 
 
 **:white_check_mark: Step-by-step directions**
 
-#### For the Amplify Console web applcation:
+#### For the Amplify Console web application:
 
 1. Launch the [Amplify Console console page][amplify-console-console].
 1. Select the application you launched today.
 1. From **Actions** in the top right corner, select *Delete App*
 1. Complete the application deletion process.
+
+#### For the IAM Role:
+
+1. Go to the [AWS IAM Console][iam-console]
+1. Select **Roles** from the navigation menu.
+1. Type `wildrydes-backend-role` into the filter box.
+1. Select the role you created in module 1.
+1. On the top left, click on the **Delete role** button.
+1. Choose **Yes, Delete** when prompted to confirm.
 
 #### For the CodeCommit repository:
 
@@ -26,4 +35,5 @@ Delete the AWS Amplify Console application and optionally the AWS CodeCommit or 
 1. Complete the repository deletion process.
 
 [amplify-console-console]: https://console.aws.amazon.com/amplify/home
+[iam-console]: https://console.aws.amazon.com/iam/home
 [codecommit-console]: https://console.aws.amazon.com/codesuite/codecommit/repositories

--- a/workshop/content/Cleanup/Module3.en.md
+++ b/workshop/content/Cleanup/Module3.en.md
@@ -24,7 +24,7 @@ Delete the AWS Lambda function, IAM role and Amazon DynamoDB table you created i
 1. Select **Roles** from the navigation menu.
 1. Type `WildRydesLambda` into the filter box.
 1. Select the role you created in module 3.
-1. From the **Role actions** drop-down, select **Delete role**.
+1. On the top left, click on the **Delete role** button.
 1. Choose **Yes, Delete** when prompted to confirm.
 
 #### DynamoDB Table


### PR DESCRIPTION
The IAM service role created during [module 1 - deploy](https://webapp.serverlessworkshops.io/staticwebhosting/deploy/) is not mentioned in the cleanup section (useful when not using Event Engine platform).
I've also fixed a typo on `applcation` -> `application`.
Finally, clarified how to delete the role (not exactly the same UX than IAM policy, just a button) in module 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
