### PR TITLE
Update WildRydesLambda runtime to Node.js 16

### DIFF
--- a/workshop/content/3-serverlessbackend/4-lambda/_index.en.md
+++ b/workshop/content/3-serverlessbackend/4-lambda/_index.en.md
@@ -19,7 +19,7 @@ Configure your function to use the `WildRydesLambda` IAM role you created in the
 2. Click **Create function**.
 3. Keep the default **Author from scratch** card selected.
 4. Enter `RequestUnicorn` in the **Name** field.
-5. Select **Node.js 12.x** for the **Runtime**.
+5. Select **Node.js 16.x** for the **Runtime**.
 6. Expand *Change default execution role* under **Permissions**.
 7. Ensure `Use an existing role` is selected from the **Role** dropdown.
 8. Select `WildRydesLambda` from the **Existing Role** dropdown.


### PR DESCRIPTION
As Node.js 12.x will be deprecated soon: https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-12-x-in-the-aws-sdk-for-javascript-v3/. Code return 201 without changing anything except the running version itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
