### PR TITLE
Lambda function: convert from CommonJS to ES Modules.

### DIFF
--- a/workshop/content/3-serverlessbackend/4-lambda/requestUnicorn.js
+++ b/workshop/content/3-serverlessbackend/4-lambda/requestUnicorn.js
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-const { randomBytes } = require('crypto');
-const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
-const { marshall } = require('@aws-sdk/util-dynamodb');
+import { randomBytes } from 'crypto';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
 
 const ddbClient = new DynamoDBClient({ region: 'us-east-1' }); // Update with your desired region
 
@@ -25,7 +25,7 @@ const fleet = [
   },
 ];
 
-exports.handler = async (event) => {
+export async function handler (event) {
   if (!event.requestContext.authorizer) {
     return errorResponse('Authorization not configured', event.requestContext.requestId);
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When creating a Lambda function in the AWS Console using the Node.js 18.x runtime, the default behaviour creates a javascript handler file named `index.mjs`, which designates the handler as an ES Module. The current Lambda function handler function is written with CommonJS conventions, which causes the Lambda function invocation to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
